### PR TITLE
small fix for non-streaming responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ wallet.sqlite3
 
 # Development 
 .notes
-.keys.db
-.wallet.sqlite3
-.models.json
+.*keys.db
+.*wallet.sqlite3
+.*models.json
 compose.override.yml

--- a/router/proxy.py
+++ b/router/proxy.py
@@ -189,10 +189,17 @@ async def proxy(
                         key, response_json, session
                     )
                     response_json["cost"] = cost_data
+
+                    response_headers = dict(response.headers)
+
+                    # Remove Transfer-Encoding header to avoid conflict with Content-Length header in common nginx setups
+                    if "transfer-encoding" in response_headers:
+                        del response_headers["transfer-encoding"]
+
                     return Response(
                         content=json.dumps(response_json).encode(),
                         status_code=response.status_code,
-                        headers=dict(response.headers),
+                        headers=response_headers,
                         media_type="application/json",
                     )
                 except json.JSONDecodeError as e:


### PR DESCRIPTION
Just a small fix for non-streaming responses. 

A few days ago, I started getting Errors when sending requests with `"stream": false` to the proxy.
The nginx error message was: `upstream sent "Content-Length" and "Transfer-Encoding" headers at the same time`.
This was likely the result of some changes from 0b97839, but I am not sure what exactly caused the change in behaviour. 

Removing the header fixes the bug. 
