### PR TITLE
Added the prepaid api key feature for self/testing.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ UPSTREAM_API_KEY="sk-21212121212121212121212121212121"
 # Lightning address used to receive funds
 RECEIVE_LN_ADDRESS="shroominic@walletofsatoshi.com"
 
+# A prepaid key you can use when you are using it yourself or while testing. Api-key doesn't need to be in any specific format but it should start with "sk-""
+PREPAID_API_KEY="sk-" # Add any string/hash here. Replace with a new string for a new API
+PREPAID_BALANCE="10000" # 10k sats
+
 # When your cashu balance reaches this number of sats, send the funds to RECEIVE_LN_ADDRESS. 
 MINIMUM_PAYOUT = "100"
 


### PR DESCRIPTION
Now any provider can set up their own API key to use via Routstr instead of topping up with Cashu tokens all the time. 

Updated .env.example

Note: If you want a new prepaid api key with new balance, just change it in .env and restart the server. 