### PR TITLE
Fix failing tests for price update error handling

### DIFF
--- a/router/models.py
+++ b/router/models.py
@@ -68,5 +68,5 @@ async def update_sats_pricing() -> None:
                     ir = model.sats_pricing.internal_reasoning * 100
                     model.sats_pricing.max_cost = p + c + r + i + w + ir
         except Exception as e:
-            print(e)
+            print('Error updating sats pricing: ', e)
         await asyncio.sleep(10)

--- a/router/price.py
+++ b/router/price.py
@@ -1,35 +1,52 @@
 import os
 import httpx
 import asyncio
+import logging
 
 # artifical spread to cover conversion fees
 EXCHANGE_FEE = float(os.environ.get("EXCHANGE_FEE", "1.005"))  # 0.5% default
 
 
-async def kraken_btc_usd(client: httpx.AsyncClient) -> float:
+async def kraken_btc_usd(client: httpx.AsyncClient) -> float | None:
     api = "https://api.kraken.com/0/public/Ticker?pair=XBTUSD"
-    return float((await client.get(api)).json()["result"]["XXBTZUSD"]["c"][0])
+    try:
+        return float((await client.get(api)).json()["result"]["XXBTZUSD"]["c"][0])
+    except (httpx.RequestError, KeyError) as e:
+        logging.warning(f"Kraken API error: {e}")
+        return None
 
 
-async def coinbase_btc_usd(client: httpx.AsyncClient) -> float:
+async def coinbase_btc_usd(client: httpx.AsyncClient) -> float | None:
     api = "https://api.coinbase.com/v2/prices/BTC-USD/spot"
-    return float((await client.get(api)).json()["data"]["amount"])
+    try:
+        return float((await client.get(api)).json()["data"]["amount"])
+    except (httpx.RequestError, KeyError) as e:
+        logging.warning(f"Coinbase API error: {e}")
+        return None
 
 
-async def binance_btc_usdt(client: httpx.AsyncClient) -> float:
+async def binance_btc_usdt(client: httpx.AsyncClient) -> float | None:
     api = "https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT"
-    return float((await client.get(api)).json()["price"])
+    try:
+        return float((await client.get(api)).json()["price"])
+    except (httpx.RequestError, KeyError) as e:
+        logging.warning(f"Binance API error: {e}")
+        return None
 
 
 async def btc_usd_ask_price() -> float:
     async with httpx.AsyncClient() as client:
         return (
             max(
-                await asyncio.gather(
-                    kraken_btc_usd(client),
-                    coinbase_btc_usd(client),
-                    binance_btc_usdt(client),
-                )
+                [
+                    price
+                    for price in await asyncio.gather(
+                        kraken_btc_usd(client),
+                        coinbase_btc_usd(client),
+                        binance_btc_usdt(client),
+                    )
+                    if price is not None
+                ]
             )
             * EXCHANGE_FEE
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -174,7 +174,8 @@ async def test_update_sats_pricing_handles_errors():
         
         def mock_print(*args, **kwargs):
             nonlocal error_printed
-            if args and isinstance(args[0], Exception) and str(args[0]) == "API Error":
+            message = " ".join(str(a) for a in args)
+            if "API Error" in message and "Error updating sats pricing" in message:
                 error_printed = True
             original_print(*args, **kwargs)
         


### PR DESCRIPTION
## Summary
- handle API errors gracefully when fetching BTC/USD prices
- tweak message when sats pricing update fails
- adjust tests for updated error log
- add newline at end of `tests/test_models.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842b2e5d2c08320a5d09ed1410ff044