### PR TITLE
Add graceful task shutdown

### DIFF
--- a/router/cashu.py
+++ b/router/cashu.py
@@ -113,6 +113,8 @@ async def check_for_refunds() -> None:
 
             # Sleep for the specified interval before checking again
             await asyncio.sleep(REFUND_PROCESSING_INTERVAL)
+        except asyncio.CancelledError:
+            break
         except Exception as e:
             print(f"Error during refund check: {e}")
 

--- a/router/models.py
+++ b/router/models.py
@@ -67,6 +67,11 @@ async def update_sats_pricing() -> None:
                     w = model.sats_pricing.web_search * 1000
                     ir = model.sats_pricing.internal_reasoning * 100
                     model.sats_pricing.max_cost = p + c + r + i + w + ir
+        except asyncio.CancelledError:
+            break
         except Exception as e:
             print(e)
-        await asyncio.sleep(10)
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            break

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,54 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from tests.conftest import TEST_ENV
+from router.main import app, lifespan
+
+
+@pytest.mark.asyncio
+async def test_background_tasks_cancel_on_shutdown():
+    pricing_started = asyncio.Event()
+    pricing_cancelled = asyncio.Event()
+
+    async def fake_update():
+        pricing_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pricing_cancelled.set()
+            raise
+
+    refund_started = asyncio.Event()
+    refund_cancelled = asyncio.Event()
+
+    async def fake_refund():
+        refund_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            refund_cancelled.set()
+            raise
+
+    with patch.dict('os.environ', TEST_ENV, clear=True):
+        mock_wallet = AsyncMock()
+        mock_wallet.__aenter__ = AsyncMock(return_value=mock_wallet)
+        mock_wallet.__aexit__ = AsyncMock(return_value=None)
+        mock_state = MagicMock()
+        mock_state.balance = 1000
+        mock_wallet.fetch_wallet_state = AsyncMock(return_value=mock_state)
+        mock_wallet.send_to_lnurl = AsyncMock(return_value=100)
+        mock_wallet.redeem = AsyncMock(return_value=None)
+        mock_wallet.send = AsyncMock(return_value='cashu:token123')
+
+        with patch('router.cashu.Wallet.create', AsyncMock(return_value=mock_wallet)), \
+             patch('router.cashu.WALLET', mock_wallet):
+
+            with patch('router.main.update_sats_pricing', new=fake_update), \
+                 patch('router.main.check_for_refunds', new=fake_refund):
+                async with lifespan(app):
+                    await pricing_started.wait()
+                    await refund_started.wait()
+
+    assert pricing_cancelled.is_set()
+    assert refund_cancelled.is_set()


### PR DESCRIPTION
## Summary
- handle `asyncio.CancelledError` in background loops
- cancel background tasks during shutdown
- test that tasks stop when the app closes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b4cc59408320a89818f48b1b2f67