### PR TITLE
Fix payout logic in cashu module

### DIFF
--- a/router/cashu.py
+++ b/router/cashu.py
@@ -33,12 +33,11 @@ async def pay_out() -> None:
         from .db import create_session
 
         async with create_session() as session:
-            balance = (
-                await session.exec(
-                    select(func.sum(col(ApiKey.balance))).where(ApiKey.balance > 0)
-                )
-            ).one()
-            if balance is None or balance == 0:
+            result = await session.exec(
+                select(func.sum(col(ApiKey.balance))).where(ApiKey.balance > 0)
+            )
+            balance = result.scalar_one_or_none()
+            if not balance:
                 # No balance to pay out - this is OK, not an error
                 return
 


### PR DESCRIPTION
## Summary
- fix balance retrieval in `pay_out`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d72595508320acdfe2ca83fb828b