### PR TITLE
Fix balance race conditions

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/router/admin.py
+++ b/router/admin.py
@@ -108,8 +108,9 @@ async def dashboard(request: Request) -> str:
             f"<tr><td>{key.hashed_key}</td><td>{key.balance}</td><td>{key.total_spent}</td><td>{key.total_requests}</td><td>{key.refund_address}</td><td>{'{} ({} UTC)'.format(key.key_expiry_time, expiry_time_human_readable) if key.key_expiry_time else key.key_expiry_time}</td></tr>"
         )
 
-    # Calculate the total balance of all API keys
-    total_user_balance = int(sum(key.balance / 1000 for key in api_keys))
+    # Calculate the total balance of all API keys using integer arithmetic to
+    # avoid rounding issues.
+    total_user_balance = sum(key.balance for key in api_keys) // 1000
     # Fetch balance from cashu
     current_balance = (await WALLET.fetch_wallet_state()).balance
     owner_balance = current_balance - total_user_balance

--- a/router/auth.py
+++ b/router/auth.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 
 from fastapi import HTTPException, Request
+from sqlalchemy import update
 
 from .cashu import credit_balance, pay_out
 from .db import ApiKey, AsyncSession
@@ -149,12 +150,31 @@ async def pay_for_request(
             },
         )
 
-    # Charge the base cost for the request
-    key.balance -= COST_PER_REQUEST
-    key.total_spent += COST_PER_REQUEST
-    key.total_requests += 1
-    session.add(key)
+    # Charge the base cost for the request atomically to avoid race conditions
+    stmt = (
+        update(ApiKey)
+        .where(ApiKey.hashed_key == key.hashed_key)
+        .where(ApiKey.balance >= COST_PER_REQUEST)
+        .values(
+            balance=ApiKey.balance - COST_PER_REQUEST,
+            total_spent=ApiKey.total_spent + COST_PER_REQUEST,
+            total_requests=ApiKey.total_requests + 1,
+        )
+    )
+    result = await session.exec(stmt)
     await session.commit()
+    if result.rowcount == 0:
+        # Another concurrent request spent the balance first
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "error": {
+                    "message": f"Insufficient balance: {COST_PER_REQUEST} mSats required. {key.balance} available.",
+                    "type": "insufficient_quota",
+                    "code": "insufficient_balance",
+                }
+            },
+        )
     await session.refresh(key)
 
 
@@ -232,6 +252,7 @@ async def adjust_payment_for_tokens(
     cost_difference = token_based_cost - COST_PER_REQUEST
 
     if cost_difference == 0:
+        await session.commit()
         return cost_data  # No adjustment needed
 
     if cost_difference > 0:
@@ -240,23 +261,39 @@ async def adjust_payment_for_tokens(
             print(
                 f"Warning: Insufficient balance for token-based pricing adjustment: {key.hashed_key[:10]}..."
             )
-            # Still proceed but log the issue - we already provided the service
-            # Add information about insufficient balance to cost data
             cost_data["warning"] = "Insufficient balance for full token-based pricing"
             cost_data["balance_shortage_msats"] = cost_difference - key.balance
+            await session.commit()
         else:
-            key.balance -= cost_difference
-            key.total_spent += cost_difference
-            cost_data["total_msats"] = COST_PER_REQUEST + cost_difference
+            stmt = (
+                update(ApiKey)
+                .where(ApiKey.hashed_key == key.hashed_key)
+                .where(ApiKey.balance >= cost_difference)
+                .values(
+                    balance=ApiKey.balance - cost_difference,
+                    total_spent=ApiKey.total_spent + cost_difference,
+                )
+            )
+            result = await session.exec(stmt)
+            await session.commit()
+            if result.rowcount:
+                cost_data["total_msats"] = COST_PER_REQUEST + cost_difference
+                await session.refresh(key)
     else:
         # Refund some of the base cost
         refund = abs(cost_difference)
-        key.balance += refund
-        key.total_spent -= refund
+        stmt = (
+            update(ApiKey)
+            .where(ApiKey.hashed_key == key.hashed_key)
+            .values(
+                balance=ApiKey.balance + refund,
+                total_spent=ApiKey.total_spent - refund,
+            )
+        )
+        await session.exec(stmt)
+        await session.commit()
         cost_data["total_msats"] = COST_PER_REQUEST - refund
-
-    session.add(key)
-    await session.commit()
+        await session.refresh(key)
 
     asyncio.create_task(pay_out())
 

--- a/router/auth.py
+++ b/router/auth.py
@@ -161,7 +161,7 @@ async def pay_for_request(
             total_requests=col(ApiKey.total_requests) + 1,
         )
     )
-    result = await session.exec(stmt)
+    result = await session.exec(stmt)  # type: ignore[call-overload]
     await session.commit()
     if result.rowcount == 0:
         # Another concurrent request spent the balance first
@@ -274,7 +274,7 @@ async def adjust_payment_for_tokens(
                     total_spent=col(ApiKey.total_spent) + cost_difference,
                 )
             )
-            result = await session.exec(charge_stmt)
+            result = await session.exec(charge_stmt)  # type: ignore[call-overload]
             await session.commit()
             if result.rowcount:
                 cost_data["total_msats"] = COST_PER_REQUEST + cost_difference
@@ -290,7 +290,7 @@ async def adjust_payment_for_tokens(
                 total_spent=col(ApiKey.total_spent) - refund,
             )
         )
-        await session.exec(refund_stmt)
+        await session.exec(refund_stmt)  # type: ignore[call-overload]
         await session.commit()
         cost_data["total_msats"] = COST_PER_REQUEST - refund
         await session.refresh(key)

--- a/router/cashu.py
+++ b/router/cashu.py
@@ -3,9 +3,7 @@ import asyncio
 import time
 
 from sixty_nuts import Wallet
-from sqlmodel import select, func, col
-from sqlalchemy import update
-from typing import Any
+from sqlmodel import select, func, col, update
 from .db import ApiKey, AsyncSession, get_session
 
 
@@ -85,12 +83,12 @@ async def credit_balance(cashu_token: str, key: ApiKey, session: AsyncSession) -
 
     # Apply the balance change atomically to avoid race conditions when topping
     # up the same key concurrently.
-    stmt: Any = (
+    stmt = (
         update(ApiKey)
-        .where(ApiKey.hashed_key == key.hashed_key)  # type: ignore[arg-type]
-        .values(balance=ApiKey.balance + amount)
+        .where(col(ApiKey.hashed_key) == key.hashed_key)
+        .values(balance=col(ApiKey.balance) + amount)
     )
-    await session.exec(stmt)  # type: ignore[arg-type]
+    await session.exec(stmt)
     await session.commit()
     await session.refresh(key)
     return amount
@@ -146,13 +144,13 @@ async def refund_balance(amount_msats: int, key: ApiKey, session: AsyncSession) 
 
     # Atomically deduct the balance to avoid race conditions when multiple
     # refunds are triggered concurrently.
-    stmt: Any = (
+    stmt = (
         update(ApiKey)
-        .where(ApiKey.hashed_key == key.hashed_key)  # type: ignore[arg-type]
-        .where(ApiKey.balance >= amount_msats)  # type: ignore[arg-type]
-        .values(balance=ApiKey.balance - amount_msats)
+        .where(col(ApiKey.hashed_key) == key.hashed_key)
+        .where(col(ApiKey.balance) >= amount_msats)
+        .values(balance=col(ApiKey.balance) - amount_msats)
     )
-    result = await session.exec(stmt)  # type: ignore[arg-type]
+    result = await session.exec(stmt)
     await session.commit()
     if result.rowcount == 0:
         raise ValueError("Insufficient balance.")

--- a/router/cashu.py
+++ b/router/cashu.py
@@ -5,6 +5,7 @@ import time
 from sixty_nuts import Wallet
 from sqlmodel import select, func, col
 from sqlalchemy import update
+from typing import Any
 from .db import ApiKey, AsyncSession, get_session
 
 
@@ -84,12 +85,12 @@ async def credit_balance(cashu_token: str, key: ApiKey, session: AsyncSession) -
 
     # Apply the balance change atomically to avoid race conditions when topping
     # up the same key concurrently.
-    stmt = (
+    stmt: Any = (
         update(ApiKey)
-        .where(ApiKey.hashed_key == key.hashed_key)
+        .where(ApiKey.hashed_key == key.hashed_key)  # type: ignore[arg-type]
         .values(balance=ApiKey.balance + amount)
     )
-    await session.exec(stmt)
+    await session.exec(stmt)  # type: ignore[arg-type]
     await session.commit()
     await session.refresh(key)
     return amount
@@ -145,13 +146,13 @@ async def refund_balance(amount_msats: int, key: ApiKey, session: AsyncSession) 
 
     # Atomically deduct the balance to avoid race conditions when multiple
     # refunds are triggered concurrently.
-    stmt = (
+    stmt: Any = (
         update(ApiKey)
-        .where(ApiKey.hashed_key == key.hashed_key)
-        .where(ApiKey.balance >= amount_msats)
+        .where(ApiKey.hashed_key == key.hashed_key)  # type: ignore[arg-type]
+        .where(ApiKey.balance >= amount_msats)  # type: ignore[arg-type]
         .values(balance=ApiKey.balance - amount_msats)
     )
-    result = await session.exec(stmt)
+    result = await session.exec(stmt)  # type: ignore[arg-type]
     await session.commit()
     if result.rowcount == 0:
         raise ValueError("Insufficient balance.")

--- a/router/cashu.py
+++ b/router/cashu.py
@@ -88,7 +88,7 @@ async def credit_balance(cashu_token: str, key: ApiKey, session: AsyncSession) -
         .where(col(ApiKey.hashed_key) == key.hashed_key)
         .values(balance=col(ApiKey.balance) + amount)
     )
-    await session.exec(stmt)
+    await session.exec(stmt)  # type: ignore[call-overload]
     await session.commit()
     await session.refresh(key)
     return amount
@@ -150,7 +150,7 @@ async def refund_balance(amount_msats: int, key: ApiKey, session: AsyncSession) 
         .where(col(ApiKey.balance) >= amount_msats)
         .values(balance=col(ApiKey.balance) - amount_msats)
     )
-    result = await session.exec(stmt)
+    result = await session.exec(stmt)  # type: ignore[call-overload]
     await session.commit()
     if result.rowcount == 0:
         raise ValueError("Insufficient balance.")


### PR DESCRIPTION
## Summary
- avoid race conditions in pay_for_request by using an atomic SQL update
- update token cost adjustments to modify balance atomically

## Testing
- `ruff check router tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684807d30ce083209cb72c07d8908d72