### PR TITLE
Use WALLET.redeem for crediting balances

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ with patch("sixty_nuts.Wallet") as mock_wallet_class:
 
     # Mock other wallet methods
     mock_wallet.send_to_lnurl = AsyncMock(return_value=100)
-    mock_wallet.redeem = AsyncMock(return_value=None)
+    mock_wallet.redeem = AsyncMock(return_value=1)
     mock_wallet.send = AsyncMock(return_value="cashu:token123")
 
     # Make the Wallet class return our mock when instantiated
@@ -110,7 +110,7 @@ def test_client() -> Generator[TestClient, None, None]:
 
             # Mock other wallet methods
             mock_wallet.send_to_lnurl = AsyncMock(return_value=100)
-            mock_wallet.redeem = AsyncMock(return_value=None)
+            mock_wallet.redeem = AsyncMock(return_value=1)
             mock_wallet.send = AsyncMock(return_value="cashu:token123")
 
             # Make the Wallet class return our mock when instantiated
@@ -145,7 +145,7 @@ async def async_client(test_session) -> AsyncGenerator[AsyncClient, None]:
 
             # Mock other wallet methods
             mock_wallet.send_to_lnurl = AsyncMock(return_value=100)
-            mock_wallet.redeem = AsyncMock(return_value=None)
+            mock_wallet.redeem = AsyncMock(return_value=1)
             mock_wallet.send = AsyncMock(return_value="cashu:token123")
 
             # Make the Wallet class return our mock when instantiated

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -38,7 +38,7 @@ async def test_background_tasks_cancel_on_shutdown():
         mock_state.balance = 1000
         mock_wallet.fetch_wallet_state = AsyncMock(return_value=mock_state)
         mock_wallet.send_to_lnurl = AsyncMock(return_value=100)
-        mock_wallet.redeem = AsyncMock(return_value=None)
+        mock_wallet.redeem = AsyncMock(return_value=1)
         mock_wallet.send = AsyncMock(return_value='cashu:token123')
 
         with patch('router.cashu.Wallet.create', AsyncMock(return_value=mock_wallet)), \


### PR DESCRIPTION
## Summary
- compute credited amount using `WALLET.redeem` instead of wallet state diff
- adjust tests to return an integer from mocked `redeem`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480bdde6648320882842ae7afaf260