### PR TITLE
Fix API key balance update issue

### DIFF
--- a/router/auth.py
+++ b/router/auth.py
@@ -71,6 +71,7 @@ async def validate_bearer_key(
                 key_expiry_time=key_expiry_time,
             )
             session.add(new_key)
+            await session.flush()  # Ensure the key is in the database before updating balance
             msats = await credit_balance(bearer_key, new_key, session)
             if msats <= 0:
                 raise Exception("Token redemption failed")

--- a/router/proxy.py
+++ b/router/proxy.py
@@ -9,7 +9,7 @@ from fastapi.responses import Response, StreamingResponse
 
 from .auth import adjust_payment_for_tokens, pay_for_request, validate_bearer_key
 from .cashu import pay_out
-from .db import AsyncSession, get_session, create_session
+from .db import AsyncSession, create_session, get_session
 
 UPSTREAM_BASE_URL = os.environ["UPSTREAM_BASE_URL"]
 UPSTREAM_API_KEY = os.environ.get("UPSTREAM_API_KEY", "")


### PR DESCRIPTION
The issue of API key creation failing to update the user's balance was resolved. Previously, in `router/auth.py`, when a new `ApiKey` object was created from a cashu token, it was added to the session via `session.add(new_key)` but not flushed to the database before `credit_balance()` was invoked. The `credit_balance()` function, located in `router/cashu.py`, utilizes an atomic `UPDATE` statement that requires the key's row to exist in the database. Without the flush, this `UPDATE` operation would silently fail to find the new key, leading to a zero balance despite successful token redemption.

The fix involved inserting `await session.flush()` in `router/auth.py` at line 73, immediately after `session.add(new_key)` and prior to the `credit_balance()` call. This ensures the newly created API key is persisted to the database, enabling the subsequent `credit_balance()` operation to correctly locate and update the balance. This prevents the loss of funds that occurred when users created new API keys with cashu tokens.