### PR TITLE
Added netowrking to access locally run models

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,8 @@ services:
       - TOR_PROXY_URL=socks5://tor:9050
     ports:
       - 8000:8000
+    extra_hosts: # Needed to access locally running models
+      - "host.docker.internal:host-gateway"
 
   tor:
     image: ghcr.io/hundehausen/tor-hidden-service:latest


### PR DESCRIPTION
The user also needs to change the URL in the .env file to `http://host.docker.internal` instead of `http://localhost`. For example, http://localhost:11434 for ollama. They also need to pass OLLAMA_ORIGINS="*" so that external sites like https://chat.routstr.com can access the Ollama inference. 